### PR TITLE
Bugfix: Do not hard code 'main' as Galaxy server name.

### DIFF
--- a/templates/ipython.mako
+++ b/templates/ipython.mako
@@ -11,14 +11,15 @@ import tempfile
 import subprocess
 import ConfigParser
 
-galaxy_root_dir = os.path.abspath(trans.app.config.root)
+galaxy_config = trans.app.config
+galaxy_root_dir = os.path.abspath(galaxy_config.root)
 history_id = trans.security.encode_id( trans.history.id )
 dataset_id = trans.security.encode_id( hda.id )
 
 config = ConfigParser.SafeConfigParser({'port': '8080'})
 config.read( os.path.join( galaxy_root_dir, 'universe_wsgi.ini' ) )
 
-galaxy_paster_port = config.getint('server:main', 'port')
+galaxy_paster_port = config.getint('server:%s' % galaxy_config.server_name, 'port')
 
 # Find out where we are
 viz_plugin_dir = config.get('app:main', 'visualization_plugins_directory')


### PR DESCRIPTION
Determine correct server name corresponding to at least a web request at runtime.
