### PR TITLE
Updated and more correct port finding.

### DIFF
--- a/templates/ie.mako
+++ b/templates/ie.mako
@@ -86,7 +86,9 @@ import ConfigParser
         Get port galaxy is running on (if running under paster)
     """
     config = ConfigParser.SafeConfigParser({'port': '8080'})
-    config.read( os.path.join( galaxy_root_dir, 'universe_wsgi.ini' ) )
+    config_file = galaxy_config.config_file
+    if config_file:
+        config.read( config_file )
 
     # uWSGI galaxy installations don't use paster and only speak uWSGI not http
     try:


### PR DESCRIPTION
This will handle the new style config file, the old style config file, and deployments where Galaxy is started with a completely different config file using the -c option.
