### PR TITLE
Adds the `-u` flag for running container with non-root privs

### DIFF
--- a/templates/ie.mako
+++ b/templates/ie.mako
@@ -194,8 +194,9 @@ import ConfigParser
     """
         Generate and return the docker command to execute
     """
-    return '%s run -d --sig-proxy=true -p %s:%s -v "%s:/import/" %s' % \
-        (self.attr.viz_config.get("docker", "command"), self.attr.PORT, self.attr.docker_port,
+    return '%s run -d -u %s --sig-proxy=true -p %s:%s -v "%s:/import/" %s' % \
+        (self.attr.viz_config.get("docker", "command"), os.geteuid(),
+         self.attr.PORT, self.attr.docker_port,
          temp_dir, self.attr.viz_config.get("docker", "image"))
 %>
 </%def>


### PR DESCRIPTION
Xref
- https://github.com/bgruening/docker-ipython-notebook/pull/20/
- https://github.com/bgruening/docker-ipython-notebook/pull/17

This is all concerning infrastructure for "non-root containers". Here we add the `-u` flag for running as a non-root user. See PR20 for more discussion/information as to the rationale for `-u`.

`geteuid` used in case they're doing something stupid when running Galaxy. We run it under supervisord, and it looks like `uid==euid`, so leaving the `euid` call "just in case".
